### PR TITLE
Removed Profile Image Tint and Constant Resizing

### DIFF
--- a/animator.js
+++ b/animator.js
@@ -38,10 +38,10 @@ class Animator {
         
         this.all_tweens.push(p5.tween.manager.addTween(this)
             .addMotions([
-                { key: 'profileImageSize', target: unitSize*25},
+                { key: 'profileImageSize', target: 1},
                 { key: 'profileImageAlpha', target: 255}
             ], 1000, "easeOutQuad")
-            .addMotion('profileImageSize',unitSize*25, 1000)
+            .addMotion('profileImageSize',1, 1000)
             .addMotion('profileImageOffset',unitSize*10, 1500,"easeInOutSin")
             .startTween());
         

--- a/projectsSectionLogic.js
+++ b/projectsSectionLogic.js
@@ -64,7 +64,7 @@ function drawProjectsSection() {
         noStroke();
         textSize(unitSize*4);
         textAlign(i%2 == 0 ? LEFT : RIGHT,CENTER);
-        text(categories[i].name,i%2 == 0 ? unitSize*6 : width-unitSize*6,startingY+triangleHeight*0.8);
+        text(categories[i].name,i%2 == 0 ? unitSize*6 : width-unitSize*6,startingY+triangleHeight*0.9);
 
         startingY += categoryHeight+triangleHeight;
     }

--- a/sketch.js
+++ b/sketch.js
@@ -46,14 +46,17 @@ function draw() {
     drawTetrisPattern();
 
     // Profile image and outline
+    push();
+    translate(widthDiv2, heightDiv2-animator.profileImageOffset)
+    scale(animator.profileImageSize);
     imageMode(CENTER);
-    tint(255,animator.profileImageAlpha);
-    image(profileImage, widthDiv2, heightDiv2-animator.profileImageOffset, animator.profileImageSize, animator.profileImageSize);
+    image(profileImage,0,0);
     noFill();
     stroke(0,0,20);
     strokeWeight(width*0.004);
-    ellipse(widthDiv2, heightDiv2-animator.profileImageOffset, animator.profileImageSize, animator.profileImageSize);
-    
+    circle(0,0, unitSize*25);
+    pop();
+
     // Title text and subtitle text
     noStroke();
     fill(255, animator.titleTextAlpha);
@@ -134,13 +137,15 @@ function windowResized() {
   resizeCanvas(windowWidth, height);
   // Reset the calculation of where the lowest point on the page is
   lowestYCoordinate = 0;
-
+  
   // Calculate all the resolution variables again
   widthDiv2 = width/2;
   heightDiv2 = windowHeight/2;
   smallestDimension = min(width,windowHeight);
   largestDimension = max(width,windowHeight);
-  unitSize = smallestDimension*0.011
+  if (isMobileDevice) unitSize = smallestDimension*0.014
+  else unitSize = smallestDimension*0.011
+  profileImage.resize(unitSize*25,unitSize*25)
   
   // Setup all parts of the scene again with the new screen dimensions
   setupTetrisPattern();

--- a/tetrisPatternLogic.js
+++ b/tetrisPatternLogic.js
@@ -70,7 +70,7 @@ function drawTetrisPattern() {
       let currentAngle = i * radians(deltaAngle);             //Calculate the angle using the equation
 
       // Don't show any pieces that would be under the profile image
-      if (distanceFromCenter < animator.profileImageSize/2 && animator.profileImageOffset < unitSize*4) continue;
+      if (distanceFromCenter < animator.profileImageSize*unitSize*12.5 && animator.profileImageOffset < unitSize*4) continue;
       
       // Calculate the "x" and "y" poition using Polar to Carteasian transformations
       let x = distanceFromCenter * cos(currentAngle) + widthDiv2;


### PR DESCRIPTION
Previously, the profile image would fade and grow according to the animation I set. This is inefficient because warping the image file and adding an alpha takes a lot of computational resources.

Now, the profile image is only resized once when the canvas changes dimension, and there is no fading.