### PR TITLE
Resized Canvas to Window Height

### DIFF
--- a/backgroundPiece.js
+++ b/backgroundPiece.js
@@ -36,7 +36,7 @@ class BackgroundPiece {
 
         // Calculate the closeness based on either the distance to the ripple (mobile) or distance to mouse (desktop)
         if (isMobileDevice) closeness = this.twistScale*2
-        else if(mousePos.x != 0 || mousePos.y-window.scrollY/2 != 0) closeness = this.getClosenessProportion();
+        else if(mousePos.x != 0 || mousePos.y-scrollY/2 != 0) closeness = this.getClosenessProportion();
         
         // Show the true color of the piece based on the closeness value
         if (closeness > 0) {
@@ -84,9 +84,9 @@ class BackgroundPiece {
     // (1 = right under the mouse, 0 = on the edge of the highlight zone, <0 = too far from mouse)
     getClosenessProportion() {
         // If the piece is too far away to be considered, leave the function
-        if(max(abs(this.location.x-mousePos.x),abs(this.location.y-mousePos.y+window.scrollY/2)) > highlightRadius) return -1;
+        if(max(abs(this.location.x-mousePos.x),abs(this.location.y-mousePos.y+scrollY/2)) > highlightRadius) return -1;
 
-        let distanceToMouse = this.getDistanceSquared(mousePos.x,mousePos.y-window.scrollY/2,this.location.x,this.location.y);
+        let distanceToMouse = this.getDistanceSquared(mousePos.x,mousePos.y-scrollY/2,this.location.x,this.location.y);
         return 1-distanceToMouse/(highlightRadius*highlightRadius);
     }
 

--- a/experienceTree.js
+++ b/experienceTree.js
@@ -48,7 +48,7 @@ function drawExperienceTree() {
 
     // Draw the tree trunk at increasing thicknesses as you go down
     stroke(255);
-    for(let y=0;y<experiencesJSON.length*unitSize*(isMobileDevice?65:45);y+=unitSize) {
+    for(let y=isMobileDevice?-unitSize*39:0;y<experiencesJSON.length*unitSize*(isMobileDevice?65:45);y+=unitSize) {
         let x = isMobileDevice ? width*0.1 : widthDiv2;
         strokeWeight(map(y,0,experiencesJSON.length*unitSize*(isMobileDevice?80:45),unitSize*0.7,unitSize*3));
         line(x,topMostY+unitSize*130+y,x,topMostY+unitSize*132+y);
@@ -104,6 +104,7 @@ class Experience {
         if (this.leaves.length != 0) strokeWeight(this.leaves[0].lifetime * 10);
         for(let i=this.leaves.length-1; i>=0; i--) {
             let leaf = this.leaves[i];
+            if(isMobileDevice && leaf.x < width*0.105) continue;
 
             if(isMobileDevice) {
                 stroke(10,140,50,200);
@@ -130,17 +131,17 @@ class Experience {
             // If a stationary leaf gets brushed by the mouse, apply the wind force and launch it
             if(leaf.isUnderMouse() && leaf.isOnBranch) leaf.launch()
 
-            if(leaf.x < 0 || leaf.x > width || leaf.y < window.scrollY || leaf.y > window.scrollY+windowHeight) continue
+            if(leaf.x < 0 || leaf.x > width || leaf.y < scrollY || leaf.y > scrollY+windowHeight) continue
             leaf.display();
         }
 
 
         // If the branches are above the screen, no need to display it
-        if(window.scrollY > this.y && this.fractalAngle == this.targetAngle) return
+        if(scrollY > this.y && this.fractalAngle == this.targetAngle) return
         
 
         // Animate the branch to grow into view when the user has scrolled to the right point, and animate it to hide once the user leaves
-        if (window.scrollY+windowHeight*0.4 >=  this.y-unitSize*90) {
+        if (scrollY+windowHeight*0.4 >=  this.y-unitSize*90) {
             if(!this.isAnimating) {
                 this.tween.pause();
                 this.tween = p5.tween.manager.addTween(this)
@@ -281,7 +282,7 @@ class Experience {
     }
 
     endAnimation() {
-        if (window.scrollY+windowHeight*0.4 >=  this.y-unitSize*90) {
+        if (scrollY+windowHeight*0.4 >=  this.y-unitSize*90) {
             if(!this.isAnimating) {
                 this.tween.pause();
                 this.tween = p5.tween.manager.addTween(this)

--- a/index.html
+++ b/index.html
@@ -27,5 +27,6 @@
     <script src="socialLink.js"></script>
     <script src="experienceTree.js"></script>
     <script src="leaf.js"></script>
+    <script src="userInteraction.js"></script>
   </body>
 </html>

--- a/leaf.js
+++ b/leaf.js
@@ -28,7 +28,7 @@ class Leaf {
     }
 
     display() {
-        if(this.x < 0 || this.x > width || this.y < window.scrollY || this.y > window.scrollY+windowHeight) return
+        if(this.x < 0 || this.x > width || this.y < scrollY || this.y > scrollY+windowHeight) return
         stroke(10,140,50,this.lifetime*200);
         strokeWeight(this.thickness);
         point(this.x, this.y);

--- a/projectCard.js
+++ b/projectCard.js
@@ -141,6 +141,6 @@ class ProjectCard {
     }
 
     isNotVisible() {
-        return window.scrollY > this.y+cardSize/2+(isMobileDevice?cardSize:0) || window.scrollY+windowHeight < this.y-cardSize/2;
+        return scrollY > this.y+cardSize/2+(isMobileDevice?cardSize:0) || scrollY+windowHeight < this.y-cardSize/2;
     }
 }

--- a/sketch.js
+++ b/sketch.js
@@ -6,6 +6,8 @@ let prevMousePos = {"x":0,"y":0};
 let prevScrollY;
 let prevParallaxPosition = 0;
 let parallaxPosition = 0;
+let scrollY = 0;
+let scrollSpeed = 0;
 
 let widthDiv2;
 let heightDiv2;
@@ -21,7 +23,6 @@ function setup() {
   isMobileDevice = displayWidth < displayHeight;
   
   windowResized();
-  if(isMobileDevice) pixelDensity(1);
   setupTetrisPattern();
 
   animator = new Animator();
@@ -32,17 +33,24 @@ function draw() {
   background(3, 15, 34);
 
   if(pmouseX != mouseX || pmouseY != mouseY) mousePos = {"x": mouseX, "y": mouseY}
-  else mousePos.y += window.scrollY-prevScrollY;
-  parallaxPosition = max(map(window.scrollY,0,windowHeight/1.5,-unitSize*10,-unitSize*50),-unitSize*50);
+  else mousePos.y += scrollY-prevScrollY;
+  parallaxPosition = max(map(scrollY,0,windowHeight/1.5,-unitSize*10,-unitSize*50),-unitSize*50);
   parallaxOffset = parallaxPosition - prevParallaxPosition;
 
   if(isMobileDevice) {
     if(frameCount % 200 == 0) ripples.push(new Ripple(width/2,heightDiv2-animator.profileImageOffset));
+    scrollY -= scrollSpeed;
+    scrollSpeed *= 0.96;
+    scrollY = constrain(scrollY,0,lowestYCoordinate-height);
+    mousePos.y = mouseY + scrollY;
+    translate(0,-scrollY);
+  } else {
+    scrollY = window.scrollY;
   }
 
-  if(window.scrollY < windowHeight) {
+  if(scrollY < windowHeight) {
     push();
-    translate(0,window.scrollY/2);
+    translate(0,scrollY/2);
     drawTetrisPattern();
 
     // Profile image and outline
@@ -102,10 +110,10 @@ function draw() {
   textAlign(CENTER,CENTER);
   textSize(unitSize*5);
   textFont(fontBold);
-  text("Contact Me", widthDiv2, height-socialsJSON.length*unitSize*6-unitSize*18);
+  text("Contact Me", widthDiv2, lowestYCoordinate-socialsJSON.length*unitSize*6-unitSize*18);
   textFont(fontRegular);
   textSize(unitSize*2.2);
-  text("No matter if it's about tech, games, or movies, let's start a chat!\nCheck out my socials below if you want to get in touch.", widthDiv2, height-socialsJSON.length*unitSize*6-unitSize*10);
+  text("No matter if it's about tech, games, or movies, let's start a chat!\nCheck out my socials below if you want to get in touch.", widthDiv2, lowestYCoordinate-socialsJSON.length*unitSize*6-unitSize*10);
   
   for(let i=0; i<cards.length; i++) {
     let card = cards[i];
@@ -116,7 +124,7 @@ function draw() {
     card.display();
 }
 
-  if(window.scrollY > height-socialLinks.length*60-windowHeight) {
+  if(scrollY > height-socialLinks.length*60-windowHeight) {
     for(let i=0; i<socialLinks.length; i++) {
       let s = socialLinks[i];
 
@@ -126,7 +134,7 @@ function draw() {
   }
   
   
-  prevScrollY = window.scrollY;
+  prevScrollY = scrollY;
   prevMousePos.x = mousePos.x;
   prevMousePos.y = mousePos.y;
   prevParallaxPosition = parallaxPosition;
@@ -134,7 +142,7 @@ function draw() {
 
 function windowResized() {
   // Change the width of the screen
-  resizeCanvas(windowWidth, height);
+  if(!isMobileDevice) resizeCanvas(windowWidth, height);
   // Reset the calculation of where the lowest point on the page is
   lowestYCoordinate = 0;
   
@@ -153,34 +161,13 @@ function windowResized() {
   setupExperienceTree();
   setupSocialLinks();
 
-  resizeCanvas(width, lowestYCoordinate);
+  if(!isMobileDevice) resizeCanvas(width, lowestYCoordinate);
 
   if (animator != null)
   animator.endStartUpAnimation();
 }
 
-// Function called once every time the mouse is pressed
-function mousePressed() {
-  // Start a new ripple animation at the cursor's current location
-  if(window.scrollY < windowHeight && !isMobileDevice) ripples.push(new Ripple(mousePos.x,mousePos.y));
-
-  if(mouseButton != LEFT) return;
-  // If the user clicks on a card that's being hovered, move to the link related to that card
-  for(let i=0; i<cards.length; i++) {
-    if(cards[i].isUnderMouse()) {
-      if (cards[i].link != "") window.location.href = cards[i].link;
-    }
-  }
-
-  for(let i=0; i<socialLinks.length; i++) {
-    if(socialLinks[i].isUnderMouse()) window.location.href = socialLinks[i].link;
-  }
-
-  for(let i=0; i<experiences.length; i++) {
-    if(experiences[i].isUnderMouse()) window.location.href = experiences[i].info['link'];
-  }
-}
-
 function distSq(x1, y1, x2, y2) {
   return (x2-x1)*(x2-x1) + (y2-y1)*(y2-y1);
 }
+

--- a/userInteraction.js
+++ b/userInteraction.js
@@ -1,0 +1,36 @@
+// Function called once every time the mouse is pressed
+function mousePressed() {
+    // Start a new ripple animation at the cursor's current location
+    if(scrollY < windowHeight && !isMobileDevice) ripples.push(new Ripple(mousePos.x,mousePos.y));
+    
+    if(mouseButton != LEFT) return;
+    // If the user clicks on a card that's being hovered, move to the link related to that card
+    for(let i=0; i<cards.length; i++) {
+      if(cards[i].isUnderMouse()) {
+        if (cards[i].link != "") window.location.href = cards[i].link;
+      }
+    }
+    
+    for(let i=0; i<socialLinks.length; i++) {
+      if(socialLinks[i].isUnderMouse()) window.location.href = socialLinks[i].link;
+    }
+    
+    for(let i=0; i<experiences.length; i++) {
+      if(experiences[i].isUnderMouse()) window.location.href = experiences[i].info['link'];
+    }
+  
+    scrollSpeed = 0;
+  }
+
+function mouseDragged() {
+    if(!isMobileDevice) return;
+
+    scrollY -= mouseY-pmouseY;
+    scrollSpeed = 0;
+}
+
+function mouseReleased() {
+    if(!isMobileDevice) return;
+
+    scrollSpeed = mouseY-pmouseY;
+}


### PR DESCRIPTION
Previously, the canvas of the program would be drawn just like the desktop version, where the height would be way bigger than the window height to account for all the information that would appear on the page. This huge canvas size decreases performance on mobile devices drastically, even if a majority of the canvas is not being rendered.

To fix this, I have fixed the height of the mobile version's canvas to be the window height, so there is no normal scrolling. Instead, I create my own custom scrolling that simply translates the page vertically according to how the user drags the mouse on the screen, acting as if the canvas was way taller.

To make this compatible with the desktop version, all window.scrollY references were replaced with scrollY, the new custom scroll variable. Then, I simply assign scrollY the value of window.scrollY, which means nothing changes for the desktop version.

For the mobile version, mouseDragged() and mouseReleased() functions have been added to simulate scrolling and scroll speed.

Also, I moved all user interaction functions to a dedicated javascript file.